### PR TITLE
Add Netflix-style recommender package with CLI, explainability, observability, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,128 @@
-# Hybrid Fuzzy-Genetic Approach to Recommendation Systems
+# Hybrid Fuzzy-Genetic Recommender (Revamped)
 
-Implementation of [Fuzzy-genetic approach to recommender systems based on a novel hybrid user model](http://www.sciencedirect.com/science/article/pii/S095741740700351X) using python and some libraries like pandas, numpy.
+This repository now includes a **modern, product-style movie recommender demo** inspired by Netflix-like “what should I watch next?” experiences.
+
+## What’s new
+
+The previous research-script style code has been complemented with a practical application layer:
+
+- ✅ **Simple UI**: interactive CLI (`app.py`) for entering tastes.
+- ✅ **Explainability**: every recommendation includes human-readable reasons.
+- ✅ **Observability**: recommendation pipeline emits logging and runtime metrics.
+- ✅ **Unit tests**: behavior-focused tests for ranking, filtering, and explainability.
+
+---
+
+## Product use case
+
+Imagine a user opening a streaming app and typing:
+
+- Likes: `Action, Sci-Fi`
+- Dislikes: `Horror`
+- Release range: `2010+`
+
+The app computes recommendations by combining:
+
+1. **Content affinity** (genre match to user tastes)
+2. **Collaborative signal** (ratings from users with similar inferred profiles)
+
+Then it returns top movies along with reasons like:
+
+- “Matches your preferred genres: Action, Sci-Fi.”
+- “Content score=1.20 and collaborative score=4.10.”
+- “Community average rating is 3.85/5.”
+
+---
+
+## Architecture
+
+### New modules
+
+- `netflix_recommender/models.py`
+  - Data classes: `User`, `Movie`, `Rating`, `Recommendation`.
+- `netflix_recommender/data.py`
+  - Loads MovieLens 100K (`u.user`, `u.item`, `u.data`) using stdlib `csv`.
+- `netflix_recommender/engine.py`
+  - Core recommendation engine, explainability, and observability report.
+- `app.py`
+  - CLI UI.
+- `tests/test_engine.py`
+  - Unit test suite.
+
+### Legacy modules
+
+Legacy research files are still present (`fgrs.py`, `gim.py`, `fuzzy_sets.py`, `genetic.py`) for reference, but the primary runnable user experience is now `app.py`.
+
+---
+
+## How recommendations are computed
+
+For each candidate movie:
+
+1. **Filter** by optional year bounds.
+2. Compute **content score** from preferred/disliked genres.
+3. Build a pseudo user profile from taste input.
+4. Find nearest users by cosine similarity against learned user profiles.
+5. Compute **collaborative score** using similarity-weighted ratings.
+6. Blend scores:
+
+```text
+final_score = 0.7 * content_score + 0.3 * collaborative_score
+```
+
+7. Attach explainability strings and return top-k sorted results.
+
+---
+
+## Explainability and observability
+
+### Explainability output
+
+Each recommendation includes:
+
+- Matched preferred genres.
+- Presence of disliked genres (if any).
+- Numeric content and collaborative scores.
+- Community average rating.
+
+### Observability output
+
+The engine returns an `ObservabilityReport` containing:
+
+- `candidate_movies`
+- `filtered_movies`
+- `elapsed_ms`
+
+And also writes structured log events:
+
+- `recommendation_started`
+- `recommendation_completed`
+
+---
+
+## Run the UI
+
+```bash
+python app.py
+```
+
+You’ll be prompted for:
+
+- Preferred genres (comma-separated)
+- Disliked genres (optional)
+- Min and max release year (optional)
+
+---
+
+## Run tests
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+---
+
+## Notes
+
+- The implementation intentionally uses Python standard library for loading/parsing data to keep local setup lightweight.
+- Movie source data is the bundled `ml-100k/` dataset.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Simple CLI UI for Netflix-style movie recommendations."""
+
+import logging
+
+from netflix_recommender.engine import RecommendationEngine, UserTasteInput, normalize_genre_input
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+    )
+
+
+def _prompt_genres(label: str) -> dict[str, float]:
+    raw = input(label).strip()
+    if not raw:
+        return {}
+    return normalize_genre_input([part.strip() for part in raw.split(",")])
+
+
+def _prompt_optional_year(label: str):
+    raw = input(label).strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        print("Invalid year entered. Ignoring this filter.")
+        return None
+
+
+def main() -> None:
+    _configure_logging()
+    print("\n🎬 Smart Watch Recommender (Netflix-style demo)")
+    print("Tell us what you like and we will suggest what to watch next.\n")
+
+    engine = RecommendationEngine.from_movielens("ml-100k")
+
+    print("Available genres include: Action, Adventure, Animation, Children's, Comedy, Crime,")
+    print("Documentary, Drama, Fantasy, Film-Noir, Horror, Musical, Mystery, Romance, Sci-Fi, Thriller, War, Western")
+
+    likes = _prompt_genres("Enter preferred genres (comma-separated): ")
+    dislikes = _prompt_genres("Enter disliked genres (comma-separated, optional): ")
+    min_year = _prompt_optional_year("Minimum release year (optional): ")
+    max_year = _prompt_optional_year("Maximum release year (optional): ")
+
+    taste = UserTasteInput(
+        preferred_genres=likes,
+        disliked_genres=dislikes,
+        min_year=min_year,
+        max_year=max_year,
+    )
+
+    recommendations, report = engine.recommend(taste, top_k=10)
+
+    print("\nTop recommendations for you:\n")
+    for idx, rec in enumerate(recommendations, start=1):
+        print(f"{idx:>2}. {rec.title} | final={rec.score:.2f}")
+        for reason in rec.explainability[:2]:
+            print(f"    - {reason}")
+
+    print("\nObservability summary:")
+    print(f"- Candidate movies considered: {report.candidate_movies}")
+    print(f"- Movies after filters: {report.filtered_movies}")
+    print(f"- Recommendation latency: {report.elapsed_ms:.2f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/fgrs.py
+++ b/fgrs.py
@@ -1,9 +1,11 @@
-import load_data
-import pandas as pd
-import numpy as np
-from fuzzy_sets import Age, GIM
-import gim
 import operator
+
+import numpy as np
+import pandas as pd
+
+import gim
+import load_data
+from fuzzy_sets import Age, GIM
 
 a = Age()
 g = GIM()
@@ -38,96 +40,111 @@ def fuzzy_distance(ui, uj):
 def recommend(neighbours, testing):
     ms = 0
     for key, item in testing.iterrows():
-        ar,m_id = item['rating'],item['movie_id']
+        ar, m_id = item['rating'], item['movie_id']
         n_ratings = []
         for i in neighbours:
             temp = df.loc[df['user_id'] == i].loc[df['movie_id'] == m_id]
             for k, it in temp.iterrows():
                 n_ratings.append(it['rating'])
-        pr = float(sum(n_ratings)) / len(n_ratings) if len(n_ratings) else 0
-        ms += abs(pr-ar)
-    print testing.shape[0]
-    return ms/testing.shape[0]
+        pr = float(sum(n_ratings)) / len(n_ratings) if len(n_ratings) else 0.0
+        ms += abs(pr - ar)
+    print(testing.shape[0])
+    return ms / testing.shape[0]
+
+
+def run(iterations=5, active_user_fraction=0.10, training_fraction=0.34):
+    maes = []
+    rng_seed = 42
 
 
 # print fuzzy_dist(35, 40, np.array([3, 4 ,5]), np.array([4, 5, 6]))
 # Data Details
-# users_cols ='user_id', 'age', 'sex', 'occupation', 'zip_code'
-# ratings_cols = 'user_id', 'movie_id', 'rating', 'unix_timestamp'
-# i_cols = ['movie_id', 'movie_title' ,'release date','video release date', 'IMDb URL', 'unknown', 'Action', 'Adventure',
-# 'Animation', 'Children\'s', 'Comedy', 'Crime', 'Documentary', 'Drama', 'Fantasy',
-# 'Film-Noir', 'Horror', 'Musical', 'Mystery', 'Romance', 'Sci-Fi', 'Thriller', 'War', 'Western']
-# All in one DataFrame
-mr_ur = pd.merge(load_data.users, load_data.ratings, on='user_id')
-df = pd.merge(mr_ur, load_data.items, on='movie_id')
-m_cols = ['unknown', 'Action', 'Adventure',
-          'Animation', 'Children\'s', 'Comedy', 'Crime', 'Documentary', 'Drama', 'Fantasy',
-          'Film-Noir', 'Horror', 'Musical', 'Mystery', 'Romance', 'Sci-Fi', 'Thriller', 'War', 'Western', 'age',
-          'user_id']
-model_data_au = pd.DataFrame(columns=m_cols)
-feature_row = pd.DataFrame(columns=m_cols)
-model_data_pu = pd.DataFrame(columns=m_cols)
-# Users who has rated movies atleast 60 movies
-top_users = load_data.df.groupby('user_id').size().sort_values(ascending=False)[:497]
+    # users_cols ='user_id', 'age', 'sex', 'occupation', 'zip_code'
+    # ratings_cols = 'user_id', 'movie_id', 'rating', 'unix_timestamp'
+    # i_cols = ['movie_id', 'movie_title' ,'release date','video release date', 'IMDb URL', 'unknown', 'Action', 'Adventure',
+    # 'Animation', 'Children\'s', 'Comedy', 'Crime', 'Documentary', 'Drama', 'Fantasy',
+    # 'Film-Noir', 'Horror', 'Musical', 'Mystery', 'Romance', 'Sci-Fi', 'Thriller', 'War', 'Western']
+    # All in one DataFrame
+    mr_ur = pd.merge(load_data.users, load_data.ratings, on='user_id')
+    global df
+    df = pd.merge(mr_ur, load_data.items, on='movie_id')
+    m_cols = ['unknown', 'Action', 'Adventure',
+              'Animation', 'Children\'s', 'Comedy', 'Crime', 'Documentary', 'Drama', 'Fantasy',
+              'Film-Noir', 'Horror', 'Musical', 'Mystery', 'Romance', 'Sci-Fi', 'Thriller', 'War', 'Western', 'age',
+              'user_id']
 
-for i in range(0, 5):
+    # Users who has rated movies atleast 60 movies
+    top_users = load_data.df.groupby('user_id').size().sort_values(ascending=False)[:497]
+
+    for run_idx in range(iterations):
     # active_users and passive_users - pd.Series()
-    active_users = top_users.sample(frac=0.10)
+        active_users = top_users.sample(frac=active_user_fraction, random_state=rng_seed + run_idx)
 
     # training_active_users = active_users.sample(frac=0.34)
     # testing_active_users = active_users.drop(training_active_users.index)
 
-    passive_users = top_users.drop(active_users.index)
+        passive_users = top_users.drop(active_users.index)
     # To change this # active users
-    tau_data = df.loc[df['user_id'].isin(active_users)][:10]
-    index = np.arange(0, tau_data.shape[0])
-    i = 0
-    for key, value in tau_data.iterrows():
-        user_ui_movies = df.loc[df['user_id'] == value['user_id']]
+        model_data_au = pd.DataFrame(columns=m_cols)
+        model_data_pu = pd.DataFrame(columns=m_cols)
 
-        training_user_movies = user_ui_movies.sample(frac=0.34)
-        feature_array = gim.gim_final(training_user_movies, value['user_id'])
+        tau_data = df.loc[df['user_id'].isin(active_users)][:10]
+        i = 0
+        for key, value in tau_data.iterrows():
+            user_ui_movies = df.loc[df['user_id'] == value['user_id']]
+
+            training_user_movies = user_ui_movies.sample(frac=training_fraction, random_state=rng_seed)
+            feature_array = gim.gim_final(training_user_movies, value['user_id'])
 
         # print 'GIM array', feature_array
-        feature_array[19], feature_array[20] = value['age'], value['user_id']
+            feature_array[19], feature_array[20] = value['age'], value['user_id']
         # print feature_array.shape
-        model_data_au.loc[i] = feature_array
-        i = i + 1
+            model_data_au.loc[i] = feature_array
+            i = i + 1
     # print model_data_au
     # print model_data_au
     # Working with passive users
     # change # of passive users
 
-    i = 0
-    pu_data = df.loc[df['user_id'].isin(passive_users)][:10]
+        i = 0
+        pu_data = df.loc[df['user_id'].isin(passive_users)][:10]
 
-    for key, value in pu_data.iterrows():
-        user_ui_movies = df.loc[df['user_id'] == value['user_id']]
-        feature_array_p = gim.gim_final(user_ui_movies, value['user_id'])
+        for key, value in pu_data.iterrows():
+            user_ui_movies = df.loc[df['user_id'] == value['user_id']]
+            feature_array_p = gim.gim_final(user_ui_movies, value['user_id'])
         # print 'GIM array', feature_array
-        feature_array_p[19], feature_array_p[20] = value['age'], value['user_id']
+            feature_array_p[19], feature_array_p[20] = value['age'], value['user_id']
         # print feature_array.shape
-        model_data_pu.loc[i] = feature_array_p
-        i = i + 1
+            model_data_pu.loc[i] = feature_array_p
+            i = i + 1
     # print model_data_au
     # print model_data_pu
 
     # fuzzy_df = pd.DataFrame(columns=m_cols)
-    fuzzy_vec = []
-    error = []
-    for key, value in model_data_au.iterrows():
-        i = 0
-        for key1, value1 in model_data_pu.iterrows():
-            fuzzy_vec.append(fuzzy_distance(value, value1))
-            # print value[i], value1[i]
-            fuzzy_vec[i] = [(sum(x for x in fuzzy_vec[i][:-1]))**0.5, fuzzy_vec[i][-1]]
-            i = i + 1
+        error = []
+        for key, value in model_data_au.iterrows():
+            fuzzy_vec = []
+            i = 0
+            for key1, value1 in model_data_pu.iterrows():
+                fuzzy_vec.append(fuzzy_distance(value, value1))
+                # print value[i], value1[i]
+                fuzzy_vec[i] = [(sum(x for x in fuzzy_vec[i][:-1])) ** 0.5, fuzzy_vec[i][-1]]
+                i = i + 1
         # print fuzzy_vec
-        neighbours = [n[1] for n in sorted(fuzzy_vec, key=operator.itemgetter(0), reverse=True)][:30]  # taking top 30
+            neighbours = [n[1] for n in sorted(fuzzy_vec, key=operator.itemgetter(0), reverse=True)][:30]  # taking top 30
         # print neighbours
-        testing_user = df.loc[df['user_id'] == value['user_id']].sample(frac=0.66)
-        e = recommend(neighbours, testing_user)
-        print e
-        error.append(e)
-    MAE = sum(error) / len(error)
-    print "MAE is" + MAE
+            testing_user = df.loc[df['user_id'] == value['user_id']].sample(frac=0.66, random_state=rng_seed)
+            e = recommend(neighbours, testing_user)
+            print(e)
+            error.append(e)
+        mae = sum(error) / len(error)
+        maes.append(mae)
+        print(f"Run {run_idx + 1} MAE: {mae:.4f}")
+
+    final_mae = sum(maes) / len(maes)
+    print(f"Overall MAE: {final_mae:.4f}")
+    return final_mae
+
+
+if __name__ == '__main__':
+    run()

--- a/genetic.py
+++ b/genetic.py
@@ -1,47 +1,37 @@
 import numpy as np
-import math
 
 
-# def costFunction():
-#    return np.random.random(1)
-
-
-def genetic(costFunction):
-    # [Init pop (pop=50), mut rate (=5%), num generations (50), chromosome/solution length (21), # winners/per gen]
+def genetic(cost_function):
+    """Simple genetic optimizer returning the best chromosome found."""
+    # [population, mutation_rate, generations, chromosome_length, winners_per_generation]
     params = [50, 0.05, 50, 21, 5]
-    # generate initial binary population
 
-    curPop = np.random.randint(2, size=(params[0], params[3]))
-    nextPop = np.zeros((curPop.shape[0], curPop.shape[1]))
-    fitVec = np.zeros((params[0], 2))
+    cur_pop = np.random.randint(2, size=(params[0], params[3]))
+    next_pop = np.zeros((cur_pop.shape[0], cur_pop.shape[1]))
+    fit_vec = np.zeros((params[0], 2))
 
-    for i in range(params[2]):
+    for _ in range(params[2]):
+        fit_vec = np.array([np.array([x, cost_function()]) for x in range(params[0])])
 
-        fitVec = np.array([np.array([x, costFunction()]) for x in range(params[0])])
-        # e.g. [0, 0.11] means that the 0th element in curPop (first solution) has an error of 0.11
-
-        # create a winners array of size winner*solution
         winners = np.zeros((params[4], params[3]))
         for n in range(len(winners)):
-            selected = np.random.choice(range(len(fitVec)), params[4] / 2,
-                                        replace=False)  # select random indexes from pop
+            selected = np.random.choice(range(len(fit_vec)), params[4] // 2, replace=False)
+            winner_idx = np.argmin(fit_vec[selected, 1])
+            winners[n] = cur_pop[int(fit_vec[selected[winner_idx]][0])]
 
-            wnr = np.argmin(fitVec[selected, 1])  # select one index with min fitness error (tournament)
-            winners[n] = curPop[int(fitVec[selected[wnr]][0])]  # add to winner population
+        next_pop[: len(winners)] = winners
 
-        nextPop[:len(winners)] = winners  # populate new gen with winners
+        repeats = (params[0] - len(winners)) // len(winners)
+        next_pop[len(winners) :] = np.array(
+            [
+                np.array(np.random.permutation(np.repeat(winners[:, x], repeats, axis=0)))
+                for x in range(winners.shape[1])
+            ]
+        ).T
 
-        # mating using crossover via permutation
-        nextPop[len(winners):] = np.array(
-            [np.array(
-                np.random.permutation(np.repeat(winners[:, x], ((params[0] - len(winners)) / len(winners)), axis=0)))
-             for x in range(winners.shape[1])]).T  # Populate the rest of the generation with offspring of mating pairs
+        mutation_mask = [float(np.random.normal(0, 2, 1)) if np.random.random() < params[1] else 1.0 for _ in range(next_pop.size)]
+        next_pop = np.multiply(next_pop, np.array(mutation_mask).reshape(next_pop.shape))
+        cur_pop = next_pop
 
-        # random mutation
-        nextPop = np.multiply(nextPop, np.matrix(
-            [np.float(np.random.normal(0, 2, 1)) if np.random.random() < params[1] else 1 for x in
-             range(nextPop.size)]).reshape(nextPop.shape))
-        curPop = nextPop
-
-    best_soln = curPop[np.argmin(fitVec[:, 1])]
+    best_soln = cur_pop[np.argmin(fit_vec[:, 1])]
     return best_soln

--- a/netflix_recommender/__init__.py
+++ b/netflix_recommender/__init__.py
@@ -1,0 +1,5 @@
+"""Netflix-style movie recommender with explainability and observability."""
+
+from .engine import RecommendationEngine, UserTasteInput
+
+__all__ = ["RecommendationEngine", "UserTasteInput"]

--- a/netflix_recommender/data.py
+++ b/netflix_recommender/data.py
@@ -1,0 +1,69 @@
+import csv
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .models import Movie, Rating, User
+
+GENRE_COLUMNS = [
+    "unknown",
+    "Action",
+    "Adventure",
+    "Animation",
+    "Children's",
+    "Comedy",
+    "Crime",
+    "Documentary",
+    "Drama",
+    "Fantasy",
+    "Film-Noir",
+    "Horror",
+    "Musical",
+    "Mystery",
+    "Romance",
+    "Sci-Fi",
+    "Thriller",
+    "War",
+    "Western",
+]
+
+
+def _safe_year(raw_date: str) -> int | None:
+    if not raw_date:
+        return None
+    parts = raw_date.split("-")
+    if len(parts) != 3:
+        return None
+    try:
+        return int(parts[2])
+    except ValueError:
+        return None
+
+
+def load_movielens_100k(dataset_dir: str | Path) -> Tuple[Dict[int, User], Dict[int, Movie], List[Rating]]:
+    dataset_dir = Path(dataset_dir)
+    users: Dict[int, User] = {}
+    movies: Dict[int, Movie] = {}
+    ratings: List[Rating] = []
+
+    with (dataset_dir / "u.user").open("r", encoding="latin-1") as f:
+        reader = csv.reader(f, delimiter="|")
+        for row in reader:
+            user_id, age, sex, occupation, _zip = row
+            users[int(user_id)] = User(int(user_id), int(age), sex, occupation)
+
+    with (dataset_dir / "u.item").open("r", encoding="latin-1") as f:
+        reader = csv.reader(f, delimiter="|")
+        for row in reader:
+            movie_id = int(row[0])
+            title = row[1]
+            year = _safe_year(row[2])
+            genres = {genre: int(row[5 + idx]) for idx, genre in enumerate(GENRE_COLUMNS)}
+            movies[movie_id] = Movie(movie_id, title, year, genres)
+
+    with (dataset_dir / "u.data").open("r", encoding="latin-1") as f:
+        reader = csv.reader(f, delimiter="\t")
+        for row in reader:
+            user_id, movie_id, rating, _ts = row
+            ratings.append(Rating(int(user_id), int(movie_id), int(rating)))
+
+    return users, movies, ratings

--- a/netflix_recommender/engine.py
+++ b/netflix_recommender/engine.py
@@ -1,0 +1,211 @@
+import logging
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Sequence
+
+from .data import GENRE_COLUMNS, load_movielens_100k
+from .models import Movie, Recommendation, Rating, User
+
+LOGGER = logging.getLogger("recommender")
+
+
+@dataclass
+class UserTasteInput:
+    preferred_genres: Dict[str, float]
+    disliked_genres: Dict[str, float] = field(default_factory=dict)
+    min_year: int | None = None
+    max_year: int | None = None
+
+
+@dataclass
+class ObservabilityReport:
+    candidate_movies: int
+    filtered_movies: int
+    elapsed_ms: float
+
+
+class RecommendationEngine:
+    def __init__(self, users: Dict[int, User], movies: Dict[int, Movie], ratings: List[Rating]) -> None:
+        self.users = users
+        self.movies = movies
+        self.ratings = ratings
+        self.genre_names = [g for g in GENRE_COLUMNS if g != "unknown"]
+
+        self.user_ratings: Dict[int, List[Rating]] = {}
+        for r in ratings:
+            self.user_ratings.setdefault(r.user_id, []).append(r)
+
+        self.movie_ratings: Dict[int, List[int]] = {}
+        for r in ratings:
+            self.movie_ratings.setdefault(r.movie_id, []).append(r.rating)
+
+        self.user_profiles = self._build_user_profiles()
+
+    @classmethod
+    def from_movielens(cls, dataset_dir: str = "ml-100k") -> "RecommendationEngine":
+        users, movies, ratings = load_movielens_100k(dataset_dir)
+        return cls(users, movies, ratings)
+
+    def _build_user_profiles(self) -> Dict[int, Dict[str, float]]:
+        profiles: Dict[int, Dict[str, float]] = {}
+        for user_id, ratings in self.user_ratings.items():
+            genre_totals = {g: 0.0 for g in self.genre_names}
+            weight_total = 0.0
+            for rating in ratings:
+                movie = self.movies.get(rating.movie_id)
+                if not movie:
+                    continue
+                centered = rating.rating - 3.0
+                if centered == 0:
+                    continue
+                for g in self.genre_names:
+                    if movie.genres.get(g, 0):
+                        genre_totals[g] += centered
+                weight_total += abs(centered)
+
+            if weight_total == 0:
+                profiles[user_id] = {g: 0.0 for g in self.genre_names}
+            else:
+                profiles[user_id] = {g: genre_totals[g] / weight_total for g in self.genre_names}
+        return profiles
+
+    def recommend(self, taste: UserTasteInput, top_k: int = 10) -> tuple[List[Recommendation], ObservabilityReport]:
+        start = time.perf_counter()
+        LOGGER.info("recommendation_started", extra={"top_k": top_k})
+
+        candidates = list(self.movies.values())
+        filtered = [m for m in candidates if self._movie_in_range(m, taste.min_year, taste.max_year)]
+
+        scored: List[Recommendation] = []
+        for movie in filtered:
+            content_score = self._content_score(movie, taste)
+            collaborative_score = self._collaborative_score(movie, taste)
+            final_score = 0.7 * content_score + 0.3 * collaborative_score
+            explainability = self._explain(movie, content_score, collaborative_score, taste)
+            scored.append(
+                Recommendation(
+                    movie_id=movie.movie_id,
+                    title=movie.title,
+                    score=final_score,
+                    content_score=content_score,
+                    collaborative_score=collaborative_score,
+                    explainability=explainability,
+                )
+            )
+
+        scored.sort(key=lambda x: x.score, reverse=True)
+        elapsed = (time.perf_counter() - start) * 1000
+        report = ObservabilityReport(
+            candidate_movies=len(candidates),
+            filtered_movies=len(filtered),
+            elapsed_ms=elapsed,
+        )
+        LOGGER.info(
+            "recommendation_completed",
+            extra={
+                "candidate_movies": report.candidate_movies,
+                "filtered_movies": report.filtered_movies,
+                "elapsed_ms": round(report.elapsed_ms, 2),
+            },
+        )
+        return scored[:top_k], report
+
+    def _movie_in_range(self, movie: Movie, min_year: int | None, max_year: int | None) -> bool:
+        if movie.release_year is None:
+            return True
+        if min_year is not None and movie.release_year < min_year:
+            return False
+        if max_year is not None and movie.release_year > max_year:
+            return False
+        return True
+
+    def _content_score(self, movie: Movie, taste: UserTasteInput) -> float:
+        if not taste.preferred_genres and not taste.disliked_genres:
+            return 0.0
+        score = 0.0
+        for genre, weight in taste.preferred_genres.items():
+            if movie.genres.get(genre, 0):
+                score += weight
+        for genre, penalty in taste.disliked_genres.items():
+            if movie.genres.get(genre, 0):
+                score -= penalty
+        return score
+
+    def _collaborative_score(self, movie: Movie, taste: UserTasteInput) -> float:
+        pseudo_profile = self._taste_to_profile(taste)
+        neighbors = self._nearest_users(pseudo_profile, k=30)
+        weighted_sum = 0.0
+        weight_total = 0.0
+        for user_id, sim in neighbors:
+            user_movie_rating = self._rating_by_user_for_movie(user_id, movie.movie_id)
+            if user_movie_rating is None:
+                continue
+            weighted_sum += sim * user_movie_rating
+            weight_total += sim
+
+        if weight_total > 0:
+            return weighted_sum / weight_total
+
+        ratings = self.movie_ratings.get(movie.movie_id, [])
+        return sum(ratings) / len(ratings) if ratings else 0.0
+
+    def _taste_to_profile(self, taste: UserTasteInput) -> Dict[str, float]:
+        profile = {g: 0.0 for g in self.genre_names}
+        for g, w in taste.preferred_genres.items():
+            if g in profile:
+                profile[g] += w
+        for g, p in taste.disliked_genres.items():
+            if g in profile:
+                profile[g] -= p
+        return profile
+
+    def _nearest_users(self, pseudo_profile: Dict[str, float], k: int = 30) -> List[tuple[int, float]]:
+        neighbors: List[tuple[int, float]] = []
+        for user_id, profile in self.user_profiles.items():
+            sim = self._cosine_similarity(pseudo_profile, profile)
+            if sim > 0:
+                neighbors.append((user_id, sim))
+        neighbors.sort(key=lambda x: x[1], reverse=True)
+        return neighbors[:k]
+
+    @staticmethod
+    def _cosine_similarity(a: Dict[str, float], b: Dict[str, float]) -> float:
+        dot = sum(a[k] * b.get(k, 0.0) for k in a.keys())
+        an = math.sqrt(sum(v * v for v in a.values()))
+        bn = math.sqrt(sum(v * v for v in b.values()))
+        if an == 0 or bn == 0:
+            return 0.0
+        return dot / (an * bn)
+
+    def _rating_by_user_for_movie(self, user_id: int, movie_id: int) -> int | None:
+        for rating in self.user_ratings.get(user_id, []):
+            if rating.movie_id == movie_id:
+                return rating.rating
+        return None
+
+    def _explain(self, movie: Movie, content_score: float, collaborative_score: float, taste: UserTasteInput) -> List[str]:
+        reasons: List[str] = []
+        matched = [g for g in taste.preferred_genres if movie.genres.get(g, 0)]
+        avoided = [g for g in taste.disliked_genres if movie.genres.get(g, 0)]
+
+        if matched:
+            reasons.append(f"Matches your preferred genres: {', '.join(matched[:3])}.")
+        if avoided:
+            reasons.append(f"Contains some less preferred genres: {', '.join(avoided[:2])}.")
+        reasons.append(f"Content score={content_score:.2f} and collaborative score={collaborative_score:.2f}.")
+
+        if movie.movie_id in self.movie_ratings:
+            avg_rating = sum(self.movie_ratings[movie.movie_id]) / len(self.movie_ratings[movie.movie_id])
+            reasons.append(f"Community average rating is {avg_rating:.2f}/5.")
+        return reasons
+
+
+def normalize_genre_input(genres: Sequence[str]) -> Dict[str, float]:
+    normalized = {}
+    valid_genres = {g.lower(): g for g in GENRE_COLUMNS if g != "unknown"}
+    for g in genres:
+        token = g.strip().lower()
+        if token in valid_genres:
+            normalized[valid_genres[token]] = 1.0
+    return normalized

--- a/netflix_recommender/models.py
+++ b/netflix_recommender/models.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class User:
+    user_id: int
+    age: int
+    sex: str
+    occupation: str
+
+
+@dataclass(frozen=True)
+class Movie:
+    movie_id: int
+    title: str
+    release_year: int | None
+    genres: Dict[str, int]
+
+
+@dataclass(frozen=True)
+class Rating:
+    user_id: int
+    movie_id: int
+    rating: int
+
+
+@dataclass
+class Recommendation:
+    movie_id: int
+    title: str
+    score: float
+    content_score: float
+    collaborative_score: float
+    explainability: List[str] = field(default_factory=list)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,60 @@
+import unittest
+
+from netflix_recommender.engine import RecommendationEngine, UserTasteInput, normalize_genre_input
+from netflix_recommender.models import Movie, Rating, User
+
+
+class RecommendationEngineTests(unittest.TestCase):
+    def setUp(self):
+        users = {
+            1: User(1, 25, "M", "engineer"),
+            2: User(2, 30, "F", "artist"),
+        }
+        movies = {
+            10: Movie(10, "Action Hit", 2020, {"Action": 1, "Drama": 0}),
+            11: Movie(11, "Drama Gem", 2019, {"Action": 0, "Drama": 1}),
+            12: Movie(12, "Action Drama", 2021, {"Action": 1, "Drama": 1}),
+        }
+        ratings = [
+            Rating(1, 10, 5),
+            Rating(1, 11, 2),
+            Rating(2, 10, 4),
+            Rating(2, 11, 5),
+            Rating(2, 12, 4),
+        ]
+        self.engine = RecommendationEngine(users, movies, ratings)
+
+    def test_recommend_prefers_matching_genres(self):
+        taste = UserTasteInput(preferred_genres={"Action": 1.0}, disliked_genres={"Drama": 0.2})
+        recs, report = self.engine.recommend(taste, top_k=2)
+
+        self.assertEqual(len(recs), 2)
+        self.assertGreaterEqual(recs[0].score, recs[1].score)
+        self.assertGreater(report.candidate_movies, 0)
+        self.assertGreater(report.filtered_movies, 0)
+
+    def test_year_filter(self):
+        taste = UserTasteInput(preferred_genres={"Action": 1.0}, min_year=2021)
+        recs, report = self.engine.recommend(taste, top_k=5)
+
+        self.assertEqual(report.filtered_movies, 1)
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0].title, "Action Drama")
+
+    def test_explainability_contains_scores(self):
+        taste = UserTasteInput(preferred_genres={"Drama": 1.0})
+        recs, _ = self.engine.recommend(taste, top_k=1)
+
+        explanation_text = " ".join(recs[0].explainability)
+        self.assertIn("Content score", explanation_text)
+        self.assertIn("collaborative score", explanation_text)
+
+
+class NormalizeInputTests(unittest.TestCase):
+    def test_normalize_genres(self):
+        normalized = normalize_genre_input(["action", "Drama", "unknown", "invalid"])
+        self.assertEqual(normalized, {"Action": 1.0, "Drama": 1.0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a simple, product-style UX for the repo so users can enter their taste and get movie recommendations (e.g., “what to watch on Netflix”).
- Make recommendations explainable and observable so outputs are human-readable and pipeline behavior is measurable.
- Improve maintainability and validation by adding explicit data models, a cleaner MovieLens loader, unit tests, and modernized legacy scripts.

### Description
- Introduced a new `netflix_recommender` package with data classes (`User`, `Movie`, `Rating`, `Recommendation`), a MovieLens 100K loader (`load_movielens_100k`), and a `RecommendationEngine` that blends content and collaborative signals and returns explainability strings and an `ObservabilityReport`.
- Added a simple interactive CLI (`app.py`) that prompts for preferred/disliked genres and optional year bounds, then prints top-k recommendations with short human-readable reasons and runtime metrics.
- Implemented input normalization via `normalize_genre_input`, deterministic sampling/seed controls in legacy code paths, and modernized legacy modules (`fgrs.py`, `genetic.py`) for Python 3 and stability.
- Expanded `README.md` with usage, architecture, algorithm behavior, explainability and observability notes, and test/run instructions; added unit tests under `tests/test_engine.py` covering ranking, year filtering, explainability, and input normalization.

### Testing
- Ran unit tests with `python -m unittest discover -s tests -v` which passed (4 tests, all OK).
- Performed a sample interactive run by piping input into `app.py` (e.g. `printf 'Action, Sci-Fi\nHorror\n1990\n1998\n' | python app.py`) which produced recommendations and observability output successfully.
- Static validation: module import paths and MovieLens loader were exercised during the tests and sample run and produced expected outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b0137be7483248f266814462c2f8f)